### PR TITLE
Update gatineau.json

### DIFF
--- a/sources/ca/qc/gatineau.json
+++ b/sources/ca/qc/gatineau.json
@@ -38,7 +38,12 @@
                         "field": "ADR_COMPLE",
                         "pattern": "(?:\\((.*?)\\))"
                     },
-                    "format": "shapefile"
+                    "format": "shapefile",
+                    
+                    "str_name": "SPECIFIQUE",
+                     "str_type": "GENERIQUE",
+                     "str_dir": "DIRECTION",
+                     "full_addr": "ADR_COMPLE"
                 }
             }
         ]


### PR DESCRIPTION
This file also has a column, "LIAISON" that contains "de", "de la"... etc. I'm not sure which field this would belong to or if there should be an additional field to retain separation.