### PR TITLE
Update prince_george.json

### DIFF
--- a/sources/ca/bc/prince_george.json
+++ b/sources/ca/bc/prince_george.json
@@ -44,7 +44,11 @@
                         "StrSuffix"
                     ],
                     "city": "Community",
-                    "region": "Province"
+                    "region": "Province",
+
+                    "str_name": "StrName",
+                    "str_type": "StrType",
+                    "str_dir": "StrSuffix"
                 }
             }
         ]


### PR DESCRIPTION
Added address field values. 

Note: Another field exists, 'FullName', which includes street name and type but not direction. I excluded it thinking it may be more consistent to concatenate the given fields in a script but let me know if this should be included.