### PR TITLE
Update rouyn_noranda.json

### DIFF
--- a/sources/ca/qc/rouyn_noranda.json
+++ b/sources/ca/qc/rouyn_noranda.json
@@ -32,7 +32,12 @@
                         "LIEN_VOIE",
                         "NOM_VOIE",
                         "ORIENTATION"
-                    ]
+                    ],
+                    
+                    "str_name": "NOM_VOIE",
+                    "str_type": "TYPE_VOIE",
+                    "str_dir": "ORIENTATION",
+                    "full_addr": "ADRESSE_COMPLETE"
                 }
             }
         ]


### PR DESCRIPTION
'LIEN_VOIE' has 'de, du, de la...', which are in 'ADRESS_COMPLETE' but not 'NOM_VOIE'. 

In other words, concatenating str_name, str_type, and str_dir will not render full_addr without 'LIEN_VOIE'.